### PR TITLE
RouteWrapper component

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
 import React, { Suspense } from 'react';
 import Home from './components/Home.jsx';

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -8,20 +8,19 @@ import { ErrorFallback } from './main.jsx';
 function App() {
   const NewsDetail = React.lazy(() => import('./components/NewsDetail.jsx'));
 
+  const RouteWrapper = ({ children }) => (
+  <ErrorBoundary FallbackComponent={ErrorFallback} onReset={() => { console.log('Error'); }}>
+     {children}
+  </ErrorBoundary>
+  )
+
   return (
      <Router>
        <Routes>
-        <Route path='/' element={<Home />} />
-        <Route
-          path="/failing"
-          element={
-            <ErrorBoundary FallbackComponent={ErrorFallback} onReset={() => { console.log('Error'); }}>
-              <Failing />
-            </ErrorBoundary>
-          }
-        />
-        <Route path='/news/detail/:title'
-          element={<Suspense fallback ={<div> Loading ... </div>}> <NewsDetail /> </Suspense> } />
+          <Route path='/' element={<RouteWrapper> <Home /></RouteWrapper>} />
+          <Route path="/failing" element={<RouteWrapper> <Failing /></RouteWrapper>} />
+          <Route path='/news/detail/:title'
+            element={<Suspense fallback ={<div> Loading ... </div>}> <NewsDetail /> </Suspense> } />
        </Routes> 
      </Router>
   )


### PR DESCRIPTION
In the simple but very efficient branch, I added a RouteWrapper component

The component:

- Takes in a `children` prop, meant to be another `component` in which an error may occur
- Wraps it in the `ErrorBoundary` component, which requires the route component, since it uses the `useNavigate` hook